### PR TITLE
Registrations UI (close #31)

### DIFF
--- a/src/lib/TableOfMetadata.svelte
+++ b/src/lib/TableOfMetadata.svelte
@@ -8,7 +8,8 @@
 		ListOfAttestations,
 		IndividualAttestation,
 		ProducedBy,
-		Relationship
+		Relationship,
+		Registration
 	} from './types';
 	export let data: ListOfAttestations;
 	export let selectedCID: string;
@@ -35,6 +36,25 @@
 		);
 	};
 
+	// Function to get all registered attribute names from the registrations data
+	const getRegisteredAttributes = (data: ListOfAttestations): Set<string> => {
+		const registeredAttrs = new Set<string>();
+		
+		const registrationsAttestation = data.find(att => getKey(att) === 'registrations');
+		if (registrationsAttestation) {
+			const registrations = getAttribute(registrationsAttestation) as Registration[];
+			if (Array.isArray(registrations)) {
+				registrations.forEach(registration => {
+					if (registration.attrs && Array.isArray(registration.attrs)) {
+						registration.attrs.forEach(attr => registeredAttrs.add(attr));
+					}
+				});
+			}
+		}
+		
+		return registeredAttrs;
+	};
+
 	$: sortedData = [...data].sort((a, b) => {
 		// Primary source attestations come first
 		if (a.isPrimarySource && !b.isPrimarySource) return -1;
@@ -43,6 +63,8 @@
 		// If both from same source, sort by key
 		return getKey(a).localeCompare(getKey(b));
 	});
+
+	$: registeredAttributes = getRegisteredAttributes(data);
 </script>
 
 <table class="divide-y divide-gray-200 w-full">
@@ -69,7 +91,7 @@
 					</div>
 				</td>
 				<td class="px-4 py-2 text-xs text-gray-500 text-right">
-					{getKey(attribute)}:
+					{#if registeredAttributes.has(getKey(attribute))}🔑 {/if}{getKey(attribute)}:
 				</td>
 				<td class="px-4 py-2 text-xs text-gray-700">
 					{#if getKey(attribute) === 'produced_by'}

--- a/src/lib/TableOfMetadata.svelte
+++ b/src/lib/TableOfMetadata.svelte
@@ -131,32 +131,7 @@
 					</div>
 				</td>
 				<td class="px-4 py-2 text-xs text-gray-500 text-right">
-					{getKey(attribute)}:{#if shouldShowCardanoRegistration(getKey(attribute), data)}
-						{@const cardanoReg = shouldShowCardanoRegistration(getKey(attribute), data)}
-						{@const explorerUrl = getBlockchainExplorerUrl(
-							cardanoReg.chain,
-							cardanoReg.data.tx_hash
-						)}
-						<br />(registered on:
-						<a
-							href={explorerUrl}
-							target="_blank"
-							rel="noopener noreferrer"
-							class="text-blue-500 hover:underline">{cardanoReg.chain}</a
-						>)
-					{:else if registeredAttributes.has(getKey(attribute))}
-						{@const registrations = registeredAttributes.get(getKey(attribute))}
-						<br />(registered on: {#each registrations || [] as registration, i}{#if i > 0},
-							{/if}{@const explorerUrl = getBlockchainExplorerUrl(
-								registration.chain,
-								registration.data.txHash
-							)}{#if explorerUrl}<a
-									href={explorerUrl}
-									target="_blank"
-									rel="noopener noreferrer"
-									class="text-blue-500 hover:underline">{registration.chain}</a
-								>{:else}{registration.chain}{/if}{/each})
-					{/if}
+					{getKey(attribute)}:
 				</td>
 				<td class="px-4 py-2 text-xs text-gray-700">
 					{#if getKey(attribute) === 'produced_by'}
@@ -187,6 +162,21 @@
 						/>
 					{:else}
 						{getAttribute(attribute)}
+					{/if}
+					{#if registeredAttributes.has(getKey(attribute))}
+						{@const registrations = registeredAttributes.get(getKey(attribute))}
+						<br /><span class="text-xs text-gray-500"
+							>(registered on: {#each registrations || [] as registration, i}{#if i > 0},
+								{/if}{@const explorerUrl = getBlockchainExplorerUrl(
+									registration.chain,
+									registration.data.txHash
+								)}{#if explorerUrl}<a
+										href={explorerUrl}
+										target="_blank"
+										rel="noopener noreferrer"
+										class="text-blue-500 hover:underline">{registration.chain}</a
+									>{:else}{registration.chain}{/if}{/each})</span
+						>
 					{/if}
 				</td>
 				<td class="px-4 py-2 text-xs text-gray-700">

--- a/src/lib/TableOfMetadata.svelte
+++ b/src/lib/TableOfMetadata.svelte
@@ -72,14 +72,16 @@
 		}
 	};
 
-	$: sortedData = [...data].sort((a, b) => {
-		// Primary source attestations come first
-		if (a.isPrimarySource && !b.isPrimarySource) return -1;
-		if (!a.isPrimarySource && b.isPrimarySource) return 1;
+	$: sortedData = [...data]
+		.filter((att) => getKey(att) !== 'registrations')
+		.sort((a, b) => {
+			// Primary source attestations come first
+			if (a.isPrimarySource && !b.isPrimarySource) return -1;
+			if (!a.isPrimarySource && b.isPrimarySource) return 1;
 
-		// If both from same source, sort by key
-		return getKey(a).localeCompare(getKey(b));
-	});
+			// If both from same source, sort by key
+			return getKey(a).localeCompare(getKey(b));
+		});
 
 	$: registeredAttributes = getRegisteredAttributes(data);
 </script>

--- a/src/lib/TableOfMetadata.svelte
+++ b/src/lib/TableOfMetadata.svelte
@@ -36,22 +36,24 @@
 		);
 	};
 
-	// Function to get all registered attribute names from the registrations data
-	const getRegisteredAttributes = (data: ListOfAttestations): Set<string> => {
-		const registeredAttrs = new Set<string>();
-		
-		const registrationsAttestation = data.find(att => getKey(att) === 'registrations');
+	// Function to get registration info for attributes from the registrations data
+	const getRegisteredAttributes = (data: ListOfAttestations): Map<string, string> => {
+		const registeredAttrs = new Map<string, string>();
+
+		const registrationsAttestation = data.find((att) => getKey(att) === 'registrations');
 		if (registrationsAttestation) {
 			const registrations = getAttribute(registrationsAttestation) as Registration[];
 			if (Array.isArray(registrations)) {
-				registrations.forEach(registration => {
+				registrations.forEach((registration) => {
 					if (registration.attrs && Array.isArray(registration.attrs)) {
-						registration.attrs.forEach(attr => registeredAttrs.add(attr));
+						registration.attrs.forEach((attr) => {
+							registeredAttrs.set(attr, registration.chain);
+						});
 					}
 				});
 			}
 		}
-		
+
 		return registeredAttrs;
 	};
 
@@ -91,7 +93,9 @@
 					</div>
 				</td>
 				<td class="px-4 py-2 text-xs text-gray-500 text-right">
-					{#if registeredAttributes.has(getKey(attribute))}🔑 {/if}{getKey(attribute)}:
+					{getKey(attribute)}:{#if registeredAttributes.has(getKey(attribute))}<br />Registered on: {registeredAttributes.get(
+							getKey(attribute)
+						)}{/if}
 				</td>
 				<td class="px-4 py-2 text-xs text-gray-700">
 					{#if getKey(attribute) === 'produced_by'}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,6 +40,17 @@ export interface Relationship {
 	witness?: CID[];
 }
 
+export interface Registration {
+	attrs: string[];
+	chain: string;
+	data: {
+		assetCid: string;
+		assetTreeCid: string;
+		order_id: string;
+		txHash: string;
+	};
+}
+
 export type IndividualAttestation = {
 	key: string;
 	value: AttestationValue;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -47,7 +47,8 @@ export interface Registration {
 		assetCid: string;
 		assetTreeCid: string;
 		order_id: string;
-		txHash: string;
+		txHash?: string;  // For Numbers
+		tx_hash?: string; // For Cardano
 	};
 }
 


### PR DESCRIPTION

For the asset: https://starlinglab.github.io/aa-explorer/?selectedCID=bafkreiakdbgsy3iw5qxx5jrrdzk4gmxmkic6kiew7b5petmyvmhorsb7ce

The Attr `sha256` was registered on numbers, and shows as more detailed inline thusly: 

<img width="511" alt="image" src="https://github.com/user-attachments/assets/1b8a1cae-fb9c-46df-a048-3e17d04179ac" />

The link directs to the relevant block explorer:
https://mainnet.num.network/tx/0x846263a465f6be79511d4fdf4a7c934695c07bf3fe647ef7ddf28ef8fb89c748